### PR TITLE
Fix dropin name of main package when %mvn_package is not called

### DIFF
--- a/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/EclipseInstallationRequest.java
+++ b/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/EclipseInstallationRequest.java
@@ -35,6 +35,8 @@ public class EclipseInstallationRequest {
 
 	private final Map<String, String> packageMappings = new LinkedHashMap<>();
 
+	private String mainPackageDropin;
+
 	public Path getBuildRoot() {
 		return buildRoot;
 	}
@@ -81,5 +83,13 @@ public class EclipseInstallationRequest {
 
 	public void addPackageMapping(String artifactId, String packageId) {
 		packageMappings.put(artifactId, packageId);
+	}
+
+	public String getMainPackageDropin() {
+		return mainPackageDropin;
+	}
+
+	public void setMainPackageDropin(String mainPackageDropin) {
+		this.mainPackageDropin = mainPackageDropin;
 	}
 }

--- a/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/impl/DefaultEclipseInstaller.java
+++ b/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/impl/DefaultEclipseInstaller.java
@@ -114,8 +114,10 @@ public class DefaultEclipseInstaller implements EclipseInstaller {
 			for (Entry<String, Set<IInstallableUnit>> entry : metapkg
 					.getPackageMap().entrySet()) {
 				String name = entry.getKey();
+				String packageDropin = name.isEmpty() ? request
+						.getMainPackageDropin() : name;
 				Dropin dropin = new Dropin(name, request
-						.getTargetDropinDirectory().resolve(name));
+						.getTargetDropinDirectory().resolve(packageDropin));
 				dropins.add(dropin);
 
 				Set<IInstallableUnit> content = entry.getValue();
@@ -124,8 +126,13 @@ public class DefaultEclipseInstaller implements EclipseInstaller {
 				content.retainAll(reactor);
 				symlinks.removeAll(content);
 
-				logger.info("Creating runnable repository for package {}...",
-						name);
+				if (name.isEmpty()) {
+					logger.info("Creating runnable repository for main package...");
+				} else {
+					logger.info(
+							"Creating runnable repository for package {}...",
+							name);
+				}
 				Repository packageRepo = Repository.createTemp();
 				Director.mirror(packageRepo, reactorRepo, content);
 				Path installationPath = dropin.getPath().resolve("eclipse");

--- a/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/impl/Package.java
+++ b/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/impl/Package.java
@@ -183,7 +183,7 @@ public class Package {
 			}
 
 			throw new RuntimeException("There are " + unmerged.size()
-					+ " unmerged virntual metapackages");
+					+ " unmerged virtual metapackages");
 		}
 	}
 

--- a/xmvn-p2-installer-plugin/src/main/java/org/fedoraproject/p2/xmvn/EclipseArtifactInstaller.java
+++ b/xmvn-p2-installer-plugin/src/main/java/org/fedoraproject/p2/xmvn/EclipseArtifactInstaller.java
@@ -84,6 +84,9 @@ public class EclipseArtifactInstaller implements ArtifactInstaller {
 		subpackageId = subpackageId.replaceAll("-+$", "");
 		subpackageId = subpackageId.replaceAll("^-+", "");
 
+		if (JavaPackage.MAIN.equals(targetPackage.getId()))
+			request.setMainPackageDropin(commonId);
+
 		if (isFeature
 				|| (rule.getTargetPackage() != null && !rule.getTargetPackage()
 						.isEmpty())) {


### PR DESCRIPTION
For simple or single feature plugins, where I want all IUs installed into the main package, I shouldn't have to specify this with a call to the "%mvn_package" macro.

If you do not make a call to "%mvn_package" then all IUs get installed into "/usr/share/eclipse/dropins" instead of the intended "/usr/share/eclipse/dropins/<dropin_name>"

This pull request fixes this simple use-case. If a target package is not specified (i.e. install into main package) then install into a dropin named after the common sub-package id.

This prevents IUs from being installed directly into the dropins directory instead of into an appropriately named directory under the dropins directory and prevents the plug-in package from accidentally owning the "/usr/share/eclipse/dropins" directory which is owned by eclipse-platform.
