### PR TITLE
Requires generation was erroneously picking the wrong SCL for deps symlinked into dropins

### DIFF
--- a/org.fedoraproject.p2.tests/src/org/fedoraproject/p2/tests/CompoundBundleRepositoryTest.java
+++ b/org.fedoraproject.p2.tests/src/org/fedoraproject/p2/tests/CompoundBundleRepositoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 Red Hat Inc.
+ * Copyright (c) 2014-2015 Red Hat Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -181,5 +181,27 @@ public class CompoundBundleRepositoryTest extends RepositoryTest {
 		// the same plugin from SCL
 		addExternalPlugin("base", "p", "1.2.3", false);
 		performTest("scl", "base");
+	}
+
+	// If a bundle both internal and external (i.e. it is symlinked into a
+	// dropin)
+	// Then the bundle should always be considered external since it is not the
+	// dropin that provides it
+	@Test
+	public void shadowingIntExtSameSCL() throws Exception {
+		addInternalPlugin("devtoolset", "org.junit", "1.0.0", false);
+		addExternalPlugin("devtoolset", "org.junit", "1.0.0", true);
+		performTest("devtoolset");
+	}
+
+	// If a bundle both internal and external in different SCLs (i.e. it is
+	// symlinked into a dropin from a dependency SCL)
+	// Then the bundle should always be considered external since it is not the
+	// dropin that provides it
+	@Test
+	public void shadowingIntExtDifferentSCL() throws Exception {
+		addInternalPlugin("devtoolset", "org.junit", "1.0.0", false);
+		addExternalPlugin("java-common", "org.junit", "1.0.0", true);
+		performTest("devtoolset", "java-common");
 	}
 }

--- a/org.fedoraproject.p2/src/org/fedoraproject/p2/AbstractBundleRepository.java
+++ b/org.fedoraproject.p2/src/org/fedoraproject/p2/AbstractBundleRepository.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (c) 2015 Red Hat Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.fedoraproject.p2;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.eclipse.equinox.p2.metadata.IInstallableUnit;
+
+/**
+ * Abstract bundle repository that contains filtering functionality so that
+ * duplicate bundles do not get returned from the
+ * {@link IFedoraBundleRepository} interface. All bundle repository
+ * implementations should extend this class and implement
+ * {@link #getDropinsLocations()}.
+ */
+public abstract class AbstractBundleRepository implements
+		IFedoraBundleRepository {
+
+	protected Set<IInstallableUnit> platformUnits;
+	protected Set<IInstallableUnit> internalUnits;
+	protected Set<IInstallableUnit> externalUnits;
+	private boolean filtered = false;
+
+	private void filterUnits() {
+		if (!filtered) {
+			internalUnits = new LinkedHashSet<>(internalUnits);
+			externalUnits = new LinkedHashSet<>(externalUnits);
+
+			Set<IInstallableUnit> commonUnits = new LinkedHashSet<>(
+					externalUnits);
+			commonUnits.retainAll(internalUnits);
+
+			internalUnits.removeAll(commonUnits);
+			externalUnits.removeAll(commonUnits);
+
+			for (IInstallableUnit unit : commonUnits) {
+				try {
+					Path path = P2Utils.getPath(unit);
+					if (path == null)
+						continue;
+					path = path.toRealPath();
+					for (Path dropin : getDropinsLocations()) {
+						if (path.startsWith(dropin))
+							internalUnits.add(unit);
+						else
+							externalUnits.add(unit);
+					}
+				} catch (IOException e) {
+				}
+			}
+			filtered = true;
+		}
+	}
+
+	public abstract Set<Path> getDropinsLocations();
+
+	@Override
+	public final Set<IInstallableUnit> getPlatformUnits() {
+		return Collections.unmodifiableSet(platformUnits);
+	}
+
+	@Override
+	public final Set<IInstallableUnit> getInternalUnits() {
+		filterUnits();
+		return Collections.unmodifiableSet(internalUnits);
+	}
+
+	@Override
+	public final Set<IInstallableUnit> getExternalUnits() {
+		filterUnits();
+		return Collections.unmodifiableSet(externalUnits);
+	}
+}

--- a/org.fedoraproject.p2/src/org/fedoraproject/p2/CompoundBundleRepository.java
+++ b/org.fedoraproject.p2/src/org/fedoraproject/p2/CompoundBundleRepository.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014 Red Hat Inc.
+ * Copyright (c) 2014-2015 Red Hat Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -10,12 +10,12 @@
  *******************************************************************************/
 package org.fedoraproject.p2;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-
-import org.eclipse.equinox.p2.metadata.IInstallableUnit;
 
 /**
  * A compound bundle repository which consists of one or more layered bundle
@@ -23,12 +23,9 @@ import org.eclipse.equinox.p2.metadata.IInstallableUnit;
  * 
  * @author Mikolaj Izdebski
  */
-public class CompoundBundleRepository implements IFedoraBundleRepository {
+public class CompoundBundleRepository extends AbstractBundleRepository {
 
-	private final List<IFedoraBundleRepository> indices;
-	private Set<IInstallableUnit> platformUnits;
-	private Set<IInstallableUnit> internalUnits;
-	private Set<IInstallableUnit> externalUnits;
+	private final List<FedoraBundleRepository> indices;
 
 	/**
 	 * Create a compound repository backed by file system locations at given
@@ -42,39 +39,31 @@ public class CompoundBundleRepository implements IFedoraBundleRepository {
 		for (SCL scl : scls) {
 			indices.add(new FedoraBundleRepository(scl));
 		}
+
+		platformUnits = new LinkedHashSet<>();
+		for (IFedoraBundleRepository index : indices) {
+			platformUnits.addAll(index.getPlatformUnits());
+		}
+
+		internalUnits = new LinkedHashSet<>();
+		for (IFedoraBundleRepository index : indices) {
+			internalUnits.addAll(index.getInternalUnits());
+		}
+		internalUnits.removeAll(platformUnits);
+
+		externalUnits = new LinkedHashSet<>();
+		for (IFedoraBundleRepository index : indices) {
+			externalUnits.addAll(index.getExternalUnits());
+		}
+		externalUnits.removeAll(platformUnits);
 	}
 
 	@Override
-	public synchronized Set<IInstallableUnit> getPlatformUnits() {
-		if (platformUnits == null) {
-			platformUnits = new LinkedHashSet<>();
-			for (IFedoraBundleRepository index : indices) {
-				platformUnits.addAll(index.getPlatformUnits());
-			}
+	public Set<Path> getDropinsLocations() {
+		Set<Path> dropinsLocations = new LinkedHashSet<>();
+		for (AbstractBundleRepository index : indices) {
+			dropinsLocations.addAll(index.getDropinsLocations());
 		}
-		return platformUnits;
+		return Collections.unmodifiableSet(dropinsLocations);
 	}
-
-	@Override
-	public synchronized Set<IInstallableUnit> getInternalUnits() {
-		if (internalUnits == null) {
-			internalUnits = new LinkedHashSet<>();
-			for (IFedoraBundleRepository index : indices) {
-				internalUnits.addAll(index.getInternalUnits());
-			}
-		}
-		return internalUnits;
-	}
-
-	@Override
-	public synchronized Set<IInstallableUnit> getExternalUnits() {
-		if (externalUnits == null) {
-			externalUnits = new LinkedHashSet<>();
-			for (IFedoraBundleRepository index : indices) {
-				externalUnits.addAll(index.getExternalUnits());
-			}
-		}
-		return externalUnits;
-	}
-
 }


### PR DESCRIPTION
Fix a problem with filtering bundles where repositories for
different SCLs would erroneously contain duplicates and the
wrong ones would be seen by the requires generator.

Signed-off-by: Mat Booth <mat.booth@redhat.com>