### PR TITLE
Allow correct installation of bundles with native components

### DIFF
--- a/org.fedoraproject.p2.tests/src/org/fedoraproject/p2/tests/Plugin.java
+++ b/org.fedoraproject.p2.tests/src/org/fedoraproject/p2/tests/Plugin.java
@@ -32,6 +32,7 @@ class Plugin {
 	private final Attributes attr = mf.getMainAttributes();
 	private Path path;
 	private String targetPackage;
+	private boolean isNative;
 
 	public Plugin(String id, String ver) {
 		attr.put(Attributes.Name.MANIFEST_VERSION, "1.0");
@@ -56,6 +57,10 @@ class Plugin {
 		return targetPackage;
 	}
 
+	public boolean isNative() {
+		return isNative;
+	}
+
 	public Plugin importPackage(String name) {
 		imports.add(name);
 		return this;
@@ -78,6 +83,11 @@ class Plugin {
 
 	public Plugin assignToTargetPackage(String pkg) {
 		targetPackage = pkg;
+		return this;
+	}
+
+	public Plugin hasNative() {
+		isNative = true;
 		return this;
 	}
 

--- a/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/EclipseArtifact.java
+++ b/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/EclipseArtifact.java
@@ -24,6 +24,8 @@ public class EclipseArtifact {
 
 	private final boolean isFeature;
 
+	private final boolean isNative;
+
 	private String targetPackage;
 
 	private String id;
@@ -34,9 +36,10 @@ public class EclipseArtifact {
 
 	private final Map<String, String> properties = new LinkedHashMap<>();
 
-	public EclipseArtifact(Path path, boolean isFeature) {
+	public EclipseArtifact(Path path, boolean isFeature, boolean isNative) {
 		this.path = path;
 		this.isFeature = isFeature;
+		this.isNative = isNative;
 	}
 
 	public Path getPath() {
@@ -45,6 +48,10 @@ public class EclipseArtifact {
 
 	public boolean isFeature() {
 		return isFeature;
+	}
+
+	public boolean isNative() {
+		return isNative;
 	}
 
 	public String getTargetPackage() {

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <tycho-version>0.22.0</tycho-version>
-    <xmvn-version>2.1.0</xmvn-version>
+    <xmvn-version>2.4.0-SNAPSHOT</xmvn-version>
   </properties>
 
   <modules>

--- a/xmvn-p2-installer-plugin/src/main/java/org/fedoraproject/p2/app/P2InstallerApp.java
+++ b/xmvn-p2-installer-plugin/src/main/java/org/fedoraproject/p2/app/P2InstallerApp.java
@@ -57,7 +57,7 @@ public class P2InstallerApp {
 		if (!cliRequest.isDryRun())
 			request.setBuildRoot(Paths.get(cliRequest.getRoot()));
 		for (String arg : cliRequest.getParameters())
-			request.addArtifact(new EclipseArtifact(Paths.get(arg), false));
+			request.addArtifact(new EclipseArtifact(Paths.get(arg), false, false));
 		if (!cliRequest.getMappings().isEmpty())
 			throw new RuntimeException("FIXME: for now subpackage mapping is disabled in P2InstallerApp");
 

--- a/xmvn-p2-installer-plugin/src/main/java/org/fedoraproject/p2/xmvn/EclipseArtifactInstaller.java
+++ b/xmvn-p2-installer-plugin/src/main/java/org/fedoraproject/p2/xmvn/EclipseArtifactInstaller.java
@@ -20,9 +20,9 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.fedoraproject.xmvn.artifact.Artifact;
 import org.fedoraproject.xmvn.artifact.DefaultArtifact;
 import org.fedoraproject.xmvn.config.PackagingRule;
@@ -31,6 +31,7 @@ import org.fedoraproject.xmvn.tools.install.ArtifactInstallationException;
 import org.fedoraproject.xmvn.tools.install.ArtifactInstaller;
 import org.fedoraproject.xmvn.tools.install.Directory;
 import org.fedoraproject.xmvn.tools.install.File;
+import org.fedoraproject.xmvn.tools.install.JarUtils;
 import org.fedoraproject.xmvn.tools.install.JavaPackage;
 import org.fedoraproject.xmvn.tools.install.RegularFile;
 import org.fedoraproject.xmvn.tools.install.SymbolicLink;
@@ -65,13 +66,18 @@ public class EclipseArtifactInstaller implements ArtifactInstaller {
 						&& !am.getClassifier().equals("sources-feature")))
 			return;
 
+		boolean isNative = false;
+		if (JarUtils.usesNativeCode(path) || JarUtils.containsNativeCode(path)) {
+			isNative = true;
+		}
+
 		String type = am.getProperties().getProperty("type");
 		boolean isFeature = type.equals("eclipse-feature");
 		EclipseArtifact provide;
 		if (type.equals("eclipse-plugin") || type.equals("eclipse-test-plugin"))
-			provide = new XMvnEclipseArtifact(path, false, am);
+			provide = new XMvnEclipseArtifact(path, false, isNative, am);
 		else if (isFeature)
-			provide = new XMvnEclipseArtifact(path, true, am);
+			provide = new XMvnEclipseArtifact(path, true, isNative, am);
 		else
 			return;
 		request.addArtifact(provide);

--- a/xmvn-p2-installer-plugin/src/main/java/org/fedoraproject/p2/xmvn/XMvnEclipseArtifact.java
+++ b/xmvn-p2-installer-plugin/src/main/java/org/fedoraproject/p2/xmvn/XMvnEclipseArtifact.java
@@ -19,14 +19,13 @@ class XMvnEclipseArtifact extends EclipseArtifact {
 
 	private final ArtifactMetadata metadata;
 
-	public XMvnEclipseArtifact(Path path, boolean isFeature,
+	public XMvnEclipseArtifact(Path path, boolean isFeature, boolean isNative,
 			ArtifactMetadata metadata) {
-		super(path, isFeature);
+		super(path, isFeature, isNative);
 		this.metadata = metadata;
 	}
 
 	public ArtifactMetadata getMetadata() {
 		return metadata;
 	}
-
 }


### PR DESCRIPTION
Allow installation of bundles with native components into the archful
dropins directory instead of the noarch dropins directory.

Re-uses a utility from xmvn to determine whether a bundle is native or
not, so we bump the xmvn dep to >= 2.4.0

Signed-off-by: Mat Booth <mat.booth@redhat.com>