### PR TITLE
Make ignoring optional deps a more fine-grained feature

### DIFF
--- a/org.fedoraproject.p2.tests/src/org/fedoraproject/p2/tests/InstallerTest.java
+++ b/org.fedoraproject.p2.tests/src/org/fedoraproject/p2/tests/InstallerTest.java
@@ -194,6 +194,10 @@ public class InstallerTest extends RepositoryTest {
 		return addFeature(id, ver, internalFeatures);
 	}
 
+	public void ignoreOptionalDeps(String iu) {
+		request.addOptionalDepsIgnored(iu);
+	}
+
 	public void performTest() throws Exception {
 		boolean visitArchful = false;
 		for (Plugin plugin : collectPlugins(reactorPlugins, reactor)) {
@@ -744,6 +748,38 @@ public class InstallerTest extends RepositoryTest {
 	public void optionalDependencyTest() throws Exception {
 		addExternalPlugin("X");
 		addReactorPlugin("A").requireBundle("X;optional=true");
+		expectPlugin("A");
+		expectSymlink("X");
+		expectRequires("X");
+		expectProvides("A");
+		performTest();
+	}
+
+	// Symlinks for optional dependencies that are specified as "ignored" should
+	// not be created.
+	@Test
+	public void optionalDependencyIgnoredTest() throws Exception {
+		ignoreOptionalDeps("B");
+		addExternalPlugin("X");
+		addExternalPlugin("Y");
+		addReactorPlugin("A").requireBundle("X;optional=true");
+		addReactorPlugin("B").requireBundle("Y;optional=true");
+		expectPlugin("A");
+		expectPlugin("B");
+		expectSymlink("X");
+		expectRequires("X");
+		expectProvides("A");
+		expectProvides("B");
+		performTest();
+	}
+
+	// As above but for optional dependencies of external units
+	@Test
+	public void optionalDependencyIgnoredExternalTest() throws Exception {
+		ignoreOptionalDeps("X");
+		addExternalPlugin("X").requireBundle("Y;optional=true");
+		addExternalPlugin("Y");
+		addReactorPlugin("A").requireBundle("X");
 		expectPlugin("A");
 		expectSymlink("X");
 		expectRequires("X");

--- a/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/EclipseInstallationRequest.java
+++ b/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/EclipseInstallationRequest.java
@@ -29,7 +29,7 @@ public class EclipseInstallationRequest {
 
 	private String mainPackageId;
 
-	private boolean ignoreOptional = false;
+	private final Set<String> optionalDepsIgnored = new LinkedHashSet<>();
 
 	public Path getBuildRoot() {
 		return buildRoot;
@@ -63,11 +63,11 @@ public class EclipseInstallationRequest {
 		this.mainPackageId = mainPackageId;
 	}
 
-	public void setIgnoreOptional(boolean ignore) {
-		ignoreOptional = ignore;
+	public Set<String> getOptionalDepsIgnored() {
+		return optionalDepsIgnored;
 	}
 
-	public boolean ignoreOptional() {
-		return ignoreOptional;
+	public void addOptionalDepsIgnored(String iu) {
+		optionalDepsIgnored.add(iu);
 	}
 }

--- a/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/impl/DefaultEclipseInstaller.java
+++ b/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/impl/DefaultEclipseInstaller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014-2015 Red Hat Inc.
+ * Copyright (c) 2014-2016 Red Hat Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -73,7 +73,7 @@ public class DefaultEclipseInstaller implements EclipseInstaller {
 
 	private IFedoraBundleRepository index;
 
-	private boolean ignoreOptional;
+	private Set<String> ignoreOptional;
 
 	private Set<IInstallableUnit> unitCache;
 
@@ -107,7 +107,7 @@ public class DefaultEclipseInstaller implements EclipseInstaller {
 			throw new RuntimeException("Reactor contains invalid plugin or feature");
 		}
 
-		ignoreOptional = request.ignoreOptional();
+		ignoreOptional = request.getOptionalDepsIgnored();
 
 		logger.info("Indexing system bundles and features...");
 		List<Path> sclConfs = request.getConfigFiles();
@@ -387,7 +387,7 @@ public class DefaultEclipseInstaller implements EclipseInstaller {
 		return true;
 	}
 
-	private static Collection<IRequirement> getRequirements(IInstallableUnit iu, boolean ignoreOptional) {
+	private static Collection<IRequirement> getRequirements(IInstallableUnit iu, Set<String> ignoreOptional) {
 		List<IRequirement> requirements = new ArrayList<>(
 				iu.getRequirements());
 		requirements.addAll(iu.getMetaRequirements());
@@ -400,7 +400,7 @@ public class DefaultEclipseInstaller implements EclipseInstaller {
 		for (Iterator<IRequirement> iterator = requirements.iterator(); iterator
 				.hasNext();) {
 			IRequirement req = iterator.next();
-			if (req.getMax() == 0 || (ignoreOptional && req.getMin() == 0))
+			if (req.getMax() == 0 || (ignoreOptional.contains(iu.getId()) && req.getMin() == 0))
 				iterator.remove();
 		}
 


### PR DESCRIPTION
We never want optional deps to be blanket ignored because that way, even if you have the optional dep installed, we will never get that extended functionality due to missing symlinks.

However, there are some optional deps for which we **never** want to add symlinks. For example, log4j has optional deps to javax.mail and some other smtp stuff and even though we know we absolutely never need these, symlinks are created anyway.

So my proposal is to make the ignoring of optional deps a more fine-grained feature. This way we can specify a list of IUs whose optional deps we want to ignore whilst keeping the symlinks for optional deps of all other IUs.