### PR TITLE
Do not create additional directory 'eclipse' in droplet folder.

### DIFF
--- a/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/impl/DefaultEclipseInstaller.java
+++ b/org.fedoraproject.p2/src/org/fedoraproject/p2/installer/impl/DefaultEclipseInstaller.java
@@ -196,7 +196,7 @@ public class DefaultEclipseInstaller implements EclipseInstaller {
 				P2Utils.dump("Dropin physical units", content);
 				P2Utils.dump("Dropin symlinks", symlinks);
 
-				Path installationPath = dropin.getPath().resolve("eclipse");
+				Path installationPath = dropin.getPath();
 				if (request.getBuildRoot() != null) {
 					Repository dropinRepo = Repository.createTemp();
 					Set<Path> dropinPaths = new LinkedHashSet<> (plugins);


### PR DESCRIPTION
Eclipse dropins supported being present directly in the dropin folder,
or under an additonally placed 'eclipse' folder. During migration to
droplets we decided to honour this format but additional patching is
needed in the platfrom to check the extra location as droplet logic
expects the content to be directly under the droplet folder.

@mbooth101 , do you remember why we had the extra 'eclipse' folder back when we used dropins ? Was it something pdebuild used to do ? I remember sometimes we had both /usr/share/eclipse/dropins/foo/{plugins,features}/ and /usr/share/eclipse/dropins/foo/eclipse/{plugins,features}/

Applying this patch would save a patch we carry in Fedora to check under 'eclipse' also.
