### PR TITLE
Add 2022-03 as default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,19 @@
     </profile>
     <profile>
       <id>2020-09</id>
+      <properties>
+        <platform-release>2020-09</platform-release>
+        <orbit-build>S20200817205214</orbit-build>
+      </properties>
+    </profile>
+    <profile>
+      <id>2022-03</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
-        <platform-release>2020-09</platform-release>
-        <orbit-build>S20200817205214</orbit-build>
+        <platform-release>2022-03</platform-release>
+        <orbit-build>R20220302172233</orbit-build>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
I added steps to https://wiki.eclipse.org/index.php?title=Orbit%2FPromotion%2C_Release%2C_and_Retention_Policies&type=revision&diff=445326&oldid=445324 - but needed small change to this repo to get it to build.